### PR TITLE
[repair]: Re-enable BSR breaking changes GitHub action

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,8 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1
-      # TODO: restore after commit to master
-      #- uses: bufbuild/buf-breaking-action@v1
-        # with:
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
         # Check breaking changes against master
-          # against: 'https://github.com/andrewtsun25/djin-proto.git#branch=master'
+          against: 'https://github.com/andrewtsun25/djin-proto.git#branch=master'

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,11 +10,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1
-      # TODO: restore after commit to master
-      # - uses: bufbuild/buf-breaking-action@v1
-        # with:
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
           # Check breaking changes against master
-            # against: 'https://github.com/andrewtsun25/djin-proto.git#branch=master,ref=HEAD~1'
+            against: 'https://github.com/andrewtsun25/djin-proto.git#branch=master,ref=HEAD~1'
       - uses: bufbuild/buf-push-action@v1
         with:
           buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
In PR #8, we temporarily disabled the check for breaking changes, as we wanted to do some major changes prior to v1 being released. Now that those changes are checked in, we want to re-enable breaking changes checks against those major changes for future changes.